### PR TITLE
add forgoten options to migration

### DIFF
--- a/modules/rbac/install/migrations/m140115_132045_auth_item_child.php
+++ b/modules/rbac/install/migrations/m140115_132045_auth_item_child.php
@@ -9,7 +9,8 @@ class m140115_132045_auth_item_child extends  yupe\components\DbMigration
             '{{user_user_auth_item_child}}', array(
                 'parent'           => "char(64) NOT NULL",
                 'child'            => "char(64) NOT NULL",
-            )
+            ),  $this->getOptions()
+
         );
 
         $this->addPrimaryKey("pk_{{user_user_auth_item_child}}_parent_child",   '{{user_user_auth_item_child}}', 'parent,child');


### PR DESCRIPTION
Без этой строки таблица создается в кодировке БД. Если она отличается от utf8, то внешний ключ создать не получится и установка модуля будет провалена.
